### PR TITLE
[props] Fixed softsign_2 verdict

### DIFF
--- a/properties/activation_functions/softsign/softsign_2_unsafe.c
+++ b/properties/activation_functions/softsign/softsign_2_unsafe.c
@@ -19,7 +19,8 @@ int main() /* check_non_decreasing */
 	float y1 = softsign(x1);
 	float y2 = softsign(x2);
 	
-	__VERIFIER_assert(islessequal(y1, y2)); /* Expected result: verification successful */
+	/* rounding the denominator may cause the softsign to decrease rather than increase */
+	__VERIFIER_assert(islessequal(y1, y2)); /* Expected result: verification failure */
 
     return 0;
 }


### PR DESCRIPTION
This PR:
- changes the verdict of ./properties/activation_functions/softsign_2_safe.c to UNSAFE
This is dues to the fact that rounding the denominator may cause the softsign to decrease rather than increase