### PR TITLE
benchmarks now generate an intermediate C file

### DIFF
--- a/includes/CMakeLists.txt
+++ b/includes/CMakeLists.txt
@@ -24,3 +24,6 @@ endif()
 # STUB
 
 add_library(stub verifier_stubs.c)
+
+# The almagamations rely on a local verifier_functions header for compilation.
+file(COPY verifier_functions.h DESTINATION ${CMAKE_BINARY_DIR}/verifier_functions.h)

--- a/properties/CMakeLists.txt
+++ b/properties/CMakeLists.txt
@@ -38,7 +38,10 @@ function(generate_amalgamation FILES NAME)
   file(WRITE ${DESTINATION}) # Create the file
 
  foreach(C IN LISTS ${FILES})
-   file(APPEND ${DESTINATION} "#include \"${C}\"\n") # Create the file
+   file(READ ${C} FILE_CONTENT)
+   string(REPLACE "\<verifier_functions.h\>" "\"verifier_functions.h\"" PREPROCESS_CONTENT ${FILE_CONTENT}) 
+   # Note: We need to force the input to be strings (using quotes) due to CMake considering ';' as a list separator.
+   file(APPEND ${DESTINATION} "${PREPROCESS_CONTENT}") # Create the file
  endforeach()
 
  # Just to check whether it compiles...

--- a/properties/activation_functions/CMakeLists.txt
+++ b/properties/activation_functions/CMakeLists.txt
@@ -12,8 +12,8 @@ foreach(benchmark ${ACTIVATION_C})
   generate_amalgamation(benchmark ${filename}-amalgamation)
   generate_benchmark_yml(${filename}-amalgamation)
   install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.i
-    DESTINATION ${CMAKE_BINARY_DIR}/export/activation_functions/)
-  install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
+                ${CMAKE_BINARY_DIR}/${filename}-amalgamation.c
+                ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
     DESTINATION ${CMAKE_BINARY_DIR}/export/activation_functions/)
 endforeach()
 

--- a/properties/hopfield_nets/softsign/CMakeLists.txt
+++ b/properties/hopfield_nets/softsign/CMakeLists.txt
@@ -12,8 +12,8 @@ foreach(width ${HOPFIELD_MODES})
     generate_amalgamation(BENCHMARKS_WITH_DEPS ${filename}-amalgamation)
     generate_benchmark_yml(${filename}-amalgamation)
     install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.i
-      DESTINATION ${CMAKE_BINARY_DIR}/export/hopfield_nets/)
-    install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.c
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
       DESTINATION ${CMAKE_BINARY_DIR}/export/hopfield_nets/)
   endforeach()
 

--- a/properties/hopfield_nets/tanh/CMakeLists.txt
+++ b/properties/hopfield_nets/tanh/CMakeLists.txt
@@ -13,8 +13,8 @@ foreach(width ${HOPFIELD_MODES})
     generate_amalgamation(BENCHMARKS_WITH_DEPS ${filename}-amalgamation)
     generate_benchmark_yml(${filename}-amalgamation)
     install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.i
-      DESTINATION ${CMAKE_BINARY_DIR}/export/hopfield_nets/)
-    install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.c
       DESTINATION ${CMAKE_BINARY_DIR}/export/hopfield_nets/)
   endforeach()
 

--- a/properties/math_functions/CMakeLists.txt
+++ b/properties/math_functions/CMakeLists.txt
@@ -7,7 +7,7 @@ foreach(benchmark ${MATH_C})
   generate_amalgamation(benchmark ${filename}-amalgamation)
   generate_benchmark_yml(${filename}-amalgamation)
   install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.i
-    DESTINATION ${CMAKE_BINARY_DIR}/export/math_functions/)
-  install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
+                ${CMAKE_BINARY_DIR}/${filename}-amalgamation.c
+                ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
     DESTINATION ${CMAKE_BINARY_DIR}/export/math_functions/)
 endforeach()

--- a/properties/poly_approx/CMakeLists.txt
+++ b/properties/poly_approx/CMakeLists.txt
@@ -15,9 +15,9 @@ foreach(width ${POLY_MODES})
     get_filename_component(filename ${benchmark} NAME)
     generate_amalgamation(BENCHMARKS_WITH_DEPS ${filename}-amalgamation)
     generate_benchmark_yml(${filename}-amalgamation)
-    install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.i
-      DESTINATION ${CMAKE_BINARY_DIR}/export/poly_approx/)
-    install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
+    install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.c
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.i
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
       DESTINATION ${CMAKE_BINARY_DIR}/export/poly_approx/)
   endforeach()
 

--- a/properties/reach_prob_density/CMakeLists.txt
+++ b/properties/reach_prob_density/CMakeLists.txt
@@ -13,8 +13,8 @@ foreach(width ${REACH_MODES})
     generate_amalgamation(BENCHMARKS_WITH_DEPS ${filename}-amalgamation)
     generate_benchmark_yml(${filename}-amalgamation)
     install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.i
-      DESTINATION ${CMAKE_BINARY_DIR}/export/reach_prob_density/)
-    install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.c
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
       DESTINATION ${CMAKE_BINARY_DIR}/export/reach_prob_density/)
   endforeach()
 

--- a/properties/reinforcement_learning/CMakeLists.txt
+++ b/properties/reinforcement_learning/CMakeLists.txt
@@ -11,8 +11,8 @@ foreach(width ${REINFORCEMENT_MODES})
     generate_amalgamation(BENCHMARKS_WITH_DEPS ${filename}-amalgamation)
     generate_benchmark_yml(${filename}-amalgamation)
     install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.i
-      DESTINATION ${CMAKE_BINARY_DIR}/export/reinforcement_learning/)
-    install(FILES ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.c
+                  ${CMAKE_BINARY_DIR}/${filename}-amalgamation.yml
       DESTINATION ${CMAKE_BINARY_DIR}/export/reinforcement_learning/)
   endforeach()
 


### PR DESCRIPTION
In order to generate the ".i" files, the idea was to generate a .c file with a bunch of includes:

```c
#include <file1.c>
#include <file2.c>
...
```

Now the .c file contains the actual contents of these includes. The only dependency left is the `verifier_functions.h` header. Which I am fine keeping explicit as it tells verifiers what "custom" functions we expect.