### PR TITLE
Fixed 0.0f in isgreaterequal()

### DIFF
--- a/properties/activation_functions/logistic/logistic_7_unsafe.c
+++ b/properties/activation_functions/logistic/logistic_7_unsafe.c
@@ -11,7 +11,7 @@ int main() /* check_symmetry */
 {
 	float x = __VERIFIER_nondet_float();
 	
-	__VERIFIER_assume(isgreaterequal(x, 0));
+	__VERIFIER_assume(isgreaterequal(x, 0.0f));
 	
 	float y = logistic(x);
 	float z = 1.0f - logistic(-x); /* Almost identical, except for subnormal numbers and rounding errors */

--- a/properties/activation_functions/softsign/softsign_5_safe.c
+++ b/properties/activation_functions/softsign/softsign_5_safe.c
@@ -11,7 +11,7 @@ int main() /* check_symmetry */
 {
 	float x = __VERIFIER_nondet_float();
 	
-	__VERIFIER_assume(isgreaterequal(x, 0) && !isinf(x));
+	__VERIFIER_assume(isgreaterequal(x, 0.0f) && !isinf(x));
 	
 	float y = softsign(x);
 	float z = -softsign(-x);

--- a/properties/activation_functions/tanh/tanh_7_safe.c
+++ b/properties/activation_functions/tanh/tanh_7_safe.c
@@ -6,7 +6,7 @@ int main() /* check_symmetry */
 {
 	float x = __VERIFIER_nondet_float();
 	
-	__VERIFIER_assume(isgreaterequal(x, 0));
+	__VERIFIER_assume(isgreaterequal(x, 0.0f));
 	
 	float y = tanhf(x);
 	float z = -tanhf(-x);

--- a/properties/math_functions/cos/cos_7_safe.c
+++ b/properties/math_functions/cos/cos_7_safe.c
@@ -6,7 +6,7 @@ int main() /* check_symmetry */
 {
 	float x = __VERIFIER_nondet_float();
 	
-	__VERIFIER_assume(isgreaterequal(x, 0) && !isinf(x));
+	__VERIFIER_assume(isgreaterequal(x, 0.0f) && !isinf(x));
 	
 	float y = cosf(x);
 	float z = cosf(-x);

--- a/properties/math_functions/erf/erf_5_safe.c
+++ b/properties/math_functions/erf/erf_5_safe.c
@@ -6,7 +6,7 @@ int main() /* check_symmetry */
 {
 	float x = __VERIFIER_nondet_float();
 	
-	__VERIFIER_assume(isgreaterequal(x, 0));
+	__VERIFIER_assume(isgreaterequal(x, 0.0f));
 	
 	float y = erff(x);
 	float z = -erff(-x);


### PR DESCRIPTION
Fixes from SV-COMP: some calls to isgreaterequal() contained a literal 0 (int) rather than 0.0f (float)