### PR TITLE
Empty bound fixes

### DIFF
--- a/properties/reinforcement_learning/lunarlander/lunarlander_26_unsafe.c
+++ b/properties/reinforcement_learning/lunarlander/lunarlander_26_unsafe.c
@@ -20,7 +20,7 @@ int main()
 
 	__VERIFIER_assume(tensor_input[0][0] >= -0.7596881158570574f && tensor_input[0][0] <= -0.6992308041429425f);
 	__VERIFIER_assume(tensor_input[0][1] >= 0.01776487014294256f && tensor_input[0][1] <= 0.07822218185705744f);
-	__VERIFIER_assume(tensor_input[0][2] >= 8.177014294255894f && tensor_input[0][2] <= 0.06053908185705745f);
+	__VERIFIER_assume(tensor_input[0][2] >= 8.177014294255894e-05f && tensor_input[0][2] <= 0.06053908185705745f);
 	__VERIFIER_assume(tensor_input[0][3] >= -0.07765323285705744f && tensor_input[0][3] <= -0.01719592114294256f);
 	__VERIFIER_assume(tensor_input[0][4] >= -0.039961814857057444f && tensor_input[0][4] <= 0.02049549685705744f);
 	__VERIFIER_assume(tensor_input[0][5] >= -0.10178652585705744f && tensor_input[0][5] <= -0.04132921414294255f);

--- a/properties/reinforcement_learning/lunarlander/lunarlander_90_safe.c
+++ b/properties/reinforcement_learning/lunarlander/lunarlander_90_safe.c
@@ -21,7 +21,7 @@ int main()
 	__VERIFIER_assume(tensor_input[0][0] >= -0.8157109601997901f && tensor_input[0][0] <= -0.72301843980021f);
 	__VERIFIER_assume(tensor_input[0][1] >= -0.01567622819978999f && tensor_input[0][1] <= 0.07701629219978999f);
 	__VERIFIER_assume(tensor_input[0][2] >= -0.06647660719978998f && tensor_input[0][2] <= 0.02621591319978999f);
-	__VERIFIER_assume(tensor_input[0][3] >= 7.766280021000854f && tensor_input[0][3] <= 0.09277018319979f);
+	__VERIFIER_assume(tensor_input[0][3] >= 7.766280021000854e-05f && tensor_input[0][3] <= 0.09277018319979f);
 	__VERIFIER_assume(tensor_input[0][4] >= 0.00018522380021000762f && tensor_input[0][4] <= 0.09287774419978999f);
 	__VERIFIER_assume(tensor_input[0][5] >= -0.03114800519978999f && tensor_input[0][5] <= 0.06154451519978999f);
 	__VERIFIER_assume(tensor_input[0][6] >= 0.9536537398002101f && tensor_input[0][6] <= 1.04634626019979f);


### PR DESCRIPTION
This PR:
- fixes some regex bug that missed the scientific notation suffix in VNN-LIB properties
- now the precondition of lunarlander_26 and lunarlander_90 are non-empty as intended