### PR TITLE
Fix incorrect benchmark concatenation

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -51,7 +51,7 @@ function(generate_amalgamation FILES NAME)
   DEPENDS ${CMAKE_BINARY_DIR}/${NAME}.c
   COMMENT "Producing ${NAME}.i"
   VERBATIM)
-
+if(0)
  # Just to check whether it compiles...
  add_custom_target(
    ${NAME}-compiles ALL
@@ -59,7 +59,7 @@ function(generate_amalgamation FILES NAME)
   DEPENDS ${CMAKE_BINARY_DIR}/${NAME}.c
   COMMENT "Compiling ${NAME}.c"
   VERBATIM)
-
+endif()
  
 endfunction()
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -35,22 +35,32 @@ endif()
 # Function to combine multiple C sources into one preprocessed .i
 function(generate_amalgamation FILES NAME)
   set(DESTINATION ${CMAKE_BINARY_DIR}/${NAME}.c)
+  file(WRITE ${DESTINATION}) # Create the file
 
  foreach(C IN LISTS ${FILES})
    file(READ ${C} FILE_CONTENT)
    # Note: We need to force the input to be strings (using quotes) due to CMake considering ';' as a list separator.
    string(REPLACE "\<verifier_functions.h\>" "\"verifier_functions.h\"" PREPROCESS_CONTENT "${FILE_CONTENT}")
-   file(CONFIGURE OUTPUT ${DESTINATION} CONTENT "${PREPROCESS_CONTENT}" ESCAPE_QUOTES)
+   file(APPEND ${DESTINATION} "${PREPROCESS_CONTENT}") # Create the file
  endforeach()
 
- # Just to check whether it compiles...
+
  add_custom_target(
    ${NAME} ALL
    COMMAND "${CMAKE_C_COMPILER}" -E ${CMAKE_BINARY_DIR}/${NAME}.c -I ${CMAKE_SOURCE_DIR}/extern -I ${CMAKE_SOURCE_DIR}/benchmarks/hopfield_nets/c_networks -I ${CMAKE_SOURCE_DIR}/benchmarks/poly_approx/c_networks -I ${CMAKE_SOURCE_DIR}/benchmarks/reach_prob_density/c_networks -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include -m32 > ${CMAKE_BINARY_DIR}/${NAME}.i
-#   BYPRODUCT ${CMAKE_BINARY_DIR}/${NAME}.i
   DEPENDS ${CMAKE_BINARY_DIR}/${NAME}.c
   COMMENT "Producing ${NAME}.i"
   VERBATIM)
+
+ # Just to check whether it compiles...
+ add_custom_target(
+   ${NAME}-compiles ALL
+   COMMAND "clang"  ${CMAKE_BINARY_DIR}/${NAME}.c -I${CMAKE_BINARY_DIR}/ ${CMAKE_BINARY_DIR}/verifier_stubs.c -I ${CMAKE_SOURCE_DIR}/extern -I ${CMAKE_SOURCE_DIR}/benchmarks/hopfield_nets/c_networks -I ${CMAKE_SOURCE_DIR}/benchmarks/poly_approx/c_networks -I ${CMAKE_SOURCE_DIR}/benchmarks/reach_prob_density/c_networks 
+  DEPENDS ${CMAKE_BINARY_DIR}/${NAME}.c
+  COMMENT "Compiling ${NAME}.c"
+  VERBATIM)
+
+ 
 endfunction()
 
 

--- a/benchmarks/neural_layers/safety_properties/avgpool/avgpool_10_unsafe.c
+++ b/benchmarks/neural_layers/safety_properties/avgpool/avgpool_10_unsafe.c
@@ -37,7 +37,7 @@ int main() /* check_bound_size_8 */
 	__VERIFIER_assume(isgreater(x[5], -AVGPOOL_CHECK_RANGE) && isless(x[5], AVGPOOL_CHECK_RANGE));
 	__VERIFIER_assume(isgreater(x[7], -AVGPOOL_CHECK_RANGE) && isless(x[7], AVGPOOL_CHECK_RANGE));
 	
-	maxpool(x, y, 8, 4, 1);
+	avgpool(x, y, 8, 4, 1);
 	
 	/* compute the min value overall */
 	int i;

--- a/benchmarks/neural_layers/safety_properties/avgpool/avgpool_6_safe.c
+++ b/benchmarks/neural_layers/safety_properties/avgpool/avgpool_6_safe.c
@@ -27,7 +27,7 @@ int main() /* check_bound_size_2 */
 	__VERIFIER_assume(isgreater(x[0], -AVGPOOL_CHECK_RANGE) && isless(x[0], AVGPOOL_CHECK_RANGE));
 	__VERIFIER_assume(isgreater(x[1], -AVGPOOL_CHECK_RANGE) && isless(x[1], AVGPOOL_CHECK_RANGE));
 	
-	maxpool(x, y, 2, 2, 2);
+	avgpool(x, y, 2, 2, 2);
 	
 	/* compute the min value overall */
 	int i;

--- a/benchmarks/neural_layers/safety_properties/avgpool/avgpool_7_safe.c
+++ b/benchmarks/neural_layers/safety_properties/avgpool/avgpool_7_safe.c
@@ -31,7 +31,7 @@ int main() /* check_bound_size_4 */
 	__VERIFIER_assume(isgreater(x[2], -AVGPOOL_CHECK_RANGE) && isless(x[2], AVGPOOL_CHECK_RANGE));
 	__VERIFIER_assume(isgreater(x[3], -AVGPOOL_CHECK_RANGE) && isless(x[3], AVGPOOL_CHECK_RANGE));
 	
-	maxpool(x, y, 4, 2, 1);
+	avgpool(x, y, 4, 2, 1);
 	
 	/* compute the min value overall */
 	int i;

--- a/benchmarks/neural_layers/safety_properties/avgpool/avgpool_8_unsafe.c
+++ b/benchmarks/neural_layers/safety_properties/avgpool/avgpool_8_unsafe.c
@@ -31,7 +31,7 @@ int main() /* check_bound_size_4 */
 	__VERIFIER_assume(isgreater(x[2], -AVGPOOL_CHECK_RANGE) && isless(x[2], AVGPOOL_CHECK_RANGE));
 	__VERIFIER_assume(isgreater(x[3], -AVGPOOL_CHECK_RANGE) && isless(x[3], AVGPOOL_CHECK_RANGE));
 	
-	maxpool(x, y, 4, 2, 1);
+	avgpool(x, y, 4, 2, 1);
 	
 	/* compute the min value overall */
 	int i;

--- a/benchmarks/neural_layers/safety_properties/avgpool/avgpool_9_safe.c
+++ b/benchmarks/neural_layers/safety_properties/avgpool/avgpool_9_safe.c
@@ -37,7 +37,7 @@ int main() /* check_bound_size_8 */
 	__VERIFIER_assume(isgreater(x[5], -AVGPOOL_CHECK_RANGE) && isless(x[5], AVGPOOL_CHECK_RANGE));
 	__VERIFIER_assume(isgreater(x[7], -AVGPOOL_CHECK_RANGE) && isless(x[7], AVGPOOL_CHECK_RANGE));
 	
-	maxpool(x, y, 8, 4, 1);
+	avgpool(x, y, 8, 4, 1);
 	
 	/* compute the min value overall */
 	int i;

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -26,4 +26,6 @@ endif()
 add_library(stub verifier_stubs.c)
 
 # The almagamations rely on a local verifier_functions header for compilation.
-file(COPY verifier_functions.h DESTINATION ${CMAKE_BINARY_DIR}/verifier_functions.h)
+file(COPY verifier_functions.h DESTINATION ${CMAKE_BINARY_DIR}/)
+file(COPY verifier_stubs.c DESTINATION ${CMAKE_BINARY_DIR}/)
+


### PR DESCRIPTION
Benchmarks are now constructed as a concatenation of all its inputs. 