### PR TITLE
added reach_error definition

### DIFF
--- a/extern/verifier_functions.h
+++ b/extern/verifier_functions.h
@@ -2,13 +2,14 @@
 #define _VERIFICATION_FUNCTIONS_H
 
 #include <stdlib.h> // for abort
+#include <assert.h> // for assert
 // Functions for verification (harness).
 // Mainly consists of assume, reach_error, and nondets
 // See: https://sv-comp.sosy-lab.org/2023/rules.php
 
 float __VERIFIER_nondet_float();
 #define __VERIFIER_assume(cond) if(!(cond)) abort();
-void reach_error();
+inline void reach_error() { assert(0); }
 
 #define __VERIFIER_assert(cond) if(!(cond)) reach_error()
 

--- a/extern/verifier_stubs.c
+++ b/extern/verifier_stubs.c
@@ -3,4 +3,3 @@
 // Just for the compiler to pass
 
 float __VERIFIER_nondet_float() { return 0; }
-void reach_error() {}


### PR DESCRIPTION
In newest sv-comp rules `reach_error` needs to be defined.